### PR TITLE
Select all filter refactoring

### DIFF
--- a/lib/testing_appserver/modules/documents/modules/documents_select_all_filter.rb
+++ b/lib/testing_appserver/modules/documents/modules/documents_select_all_filter.rb
@@ -2,11 +2,9 @@
 
 module TestingAppServer
   # AppServer Documents select all filter
-  # https://user-images.githubusercontent.com/40513035/154398918-e0232123-9b8b-499d-ac86-1eaab0be015a.png
+  # https://user-images.githubusercontent.com/40513035/169463896-2be2c558-a153-49d4-b3d6-7fbc07db020b.png
   module DocumentsSelectAllFilter
     include PageObject
-
-    label(:select_all_checkbox, xpath: "//label[contains(@class, 'table-container_header-checkbox')]")
 
     div(:select_all_filter, xpath: "(//div[contains(@class, 'combo-button')])[1]") # add_id
     div(:select_all, xpath: "//div[@label='All']") # add_id
@@ -19,11 +17,6 @@ module TestingAppServer
     div(:select_spreadsheets, xpath: "//div[@label='Spreadsheets']") # add_id
     div(:select_all_files, xpath: "//div[@label='All files']") # add_id
 
-    def select_all_files
-      select_all_checkbox_element.click
-      @instance.webdriver.wait_until { select_all_filter_element.present? }
-    end
-
     def select_files_filter(type)
       open_select_all_filter
       instance_eval("select_#{type}_element.click", __FILE__, __LINE__) # choose filter for Select All checkbox
@@ -31,7 +24,6 @@ module TestingAppServer
     end
 
     def open_select_all_filter
-      select_all_files
       select_all_filter_element.click
       @instance.webdriver.wait_until { select_documents_element.present? }
     end

--- a/spec/spec_helper/shared_examples/documents_select_all_checkbox.rb
+++ b/spec/spec_helper/shared_examples/documents_select_all_checkbox.rb
@@ -2,10 +2,7 @@
 
 shared_examples_for 'documents_select_all_checkbox' do |folder, all_files_and_folders, document_name,
   spreadsheet_name, presentation_name, audio_name, archive_name, picture_name, folder_name|
-  it "[#{folder}] `Select all` checkbox works" do
-    documents_page.select_all_files
-    expect(documents_page).to be_files_checked(all_files_and_folders)
-  end
+  before { documents_page.check_file_checkbox(document_name) }
 
   it "[#{folder}] `Select all Documents` works" do
     documents_page.select_files_filter(:documents)


### PR DESCRIPTION
For version 1.1 `Select All` checkbox was on the top of documents list
<img width="905" alt="Screen Shot 2022-05-19 at 23 11 28" src="https://user-images.githubusercontent.com/40513035/169464268-b8be6f18-f48d-4697-ad95-46ecdceec8db.png">
For version 1.2 `Select All` appears only after any of the files selection
Before checkbox selection:
<img width="732" alt="Screen Shot 2022-05-19 at 23 16 22" src="https://user-images.githubusercontent.com/40513035/169464842-5eb756d1-c0bf-43ae-a9ab-10fe11e65f30.png">
After:
<img width="804" alt="Screen Shot 2022-05-19 at 23 16 51" src="https://user-images.githubusercontent.com/40513035/169464902-9d77b3d8-3864-497f-8e32-16f0073f9e14.png">


