### PR TITLE
For documents account check only part of folders title

### DIFF
--- a/lib/testing_appserver/data/general_data.rb
+++ b/lib/testing_appserver/data/general_data.rb
@@ -17,12 +17,12 @@ module TestingAppServer
     end
 
     def self.webdav_accounts_files
-      ['New_Folder_2_228781333', 'New_Folder_1_228770401', 'имя с пробелом_3.pptx', 'ann_test.xlsx', 'Collaborative.docx',
+      ['New_Folder_2', 'New_Folder_1', 'имя с пробелом_3.pptx', 'ann_test.xlsx', 'Collaborative.docx',
        'zip_with_txt.zip', 'э_picture_2.png']
     end
 
     def self.yandex_accounts_files
-      ['New_Folder_2_674280522', 'New_Folder_1_674271651', 'имя с пробелом_3.pptx', 'ann_test.xlsx', 'Collaborative.docx',
+      ['New_Folder_2', 'New_Folder_1', 'имя с пробелом_3.pptx', 'ann_test.xlsx', 'Collaborative.docx',
        'zip_with_txt.zip', 'э_picture_2.png']
     end
 


### PR DESCRIPTION
As folders names are changing in [Onlyoffice portals](https://github.com/ONLYOFFICE-QA/testing-onlyoffice/blob/1ed4252536aa5e54c8dd273d567d455c2bab85ea/spec/portals/documents/single_account/documents_yandex_spec.rb#L34) check only part of folder title in Appserver portals and Personal.